### PR TITLE
Fix: PHP syntax is written like JavaScript in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ For example:
 
 ```php
 try { 
-  $klaviyo.Metrics.getMetrics();
+  $klaviyo->Metrics->getMetrics();
 } catch (Exception $e) {
   if ($e->getCode() == SOME_INTEGER) {
     doSomething();


### PR DESCRIPTION
In Readme file there was a case in which PHP was written like JavaScript. I fixed it.