### PR TITLE
Add type hints to KlaviyoAPI via PHPDoc

### DIFF
--- a/lib/KlaviyoAPI.php
+++ b/lib/KlaviyoAPI.php
@@ -29,42 +29,73 @@ use KlaviyoAPI\API\WebhooksApi;
 
 
 class KlaviyoAPI {
+    /** @var string */
     public $api_key = "API_KEY";
+    /** @var int */
     public $wait_seconds;
+    /** @var int */
     public $num_retries;
+    /** @var string */
     public $config;
+    /** @var array */
     public $guzzle_options;
+    /** @var Subclient<AccountsApi> */
     public $Accounts;
+    /** @var Subclient<CampaignsApi> */
     public $Campaigns;
+    /** @var Subclient<CatalogsApi> */
     public $Catalogs;
+    /** @var Subclient<CouponsApi> */
     public $Coupons;
+    /** @var Subclient<DataPrivacyApi> */
     public $DataPrivacy;
+    /** @var Subclient<EventsApi> */
     public $Events;
+    /** @var Subclient<FlowsApi> */
     public $Flows;
+    /** @var Subclient<FormsApi> */
     public $Forms;
+    /** @var Subclient<ImagesApi> */
     public $Images;
+    /** @var Subclient<ListsApi> */
     public $Lists;
+    /** @var Subclient<MetricsApi> */
     public $Metrics;
+    /** @var Subclient<ProfilesApi> */
     public $Profiles;
+    /** @var Subclient<ReportingApi> */
     public $Reporting;
+    /** @var Subclient<ReviewsApi> */
     public $Reviews;
+    /** @var Subclient<SegmentsApi> */
     public $Segments;
+    /** @var Subclient<TagsApi> */
     public $Tags;
+    /** @var Subclient<TemplatesApi> */
     public $Templates;
+    /** @var Subclient */
     public $TrackingSettings;
+    /** @var Subclient */
     public $Webhooks;
-    
 
 
+
+    /**
+     * @param string $api_key
+     * @param int $num_retries
+     * @param ?int $wait_seconds
+     * @param array $guzzle_options
+     * @param string $user_agent_suffix
+     */
     public function __construct($api_key, $num_retries = 3, $wait_seconds = null, $guzzle_options = [], $user_agent_suffix = "") {
 
         if (gettype($num_retries) == 'NULL'){
             $num_retries = 3;
-        } 
+        }
 
         if ($wait_seconds !== null){
             trigger_error("The 'wait_seconds' parameter is deprecated and will be removed in a future version. Please remove this to enable exponential backoff for retry intervals.", E_USER_WARNING);
-        } 
+        }
 
         $this->api_key = $api_key;
         $this->num_retries = $num_retries;
@@ -77,121 +108,121 @@ class KlaviyoAPI {
         $user_agent = $user_agent . $user_agent_suffix;
         $this->config->setUserAgent($user_agent);
 
-        
+
         $this->Accounts = new Subclient(
                 new AccountsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Campaigns = new Subclient(
                 new CampaignsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Catalogs = new Subclient(
                 new CatalogsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Coupons = new Subclient(
                 new CouponsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->DataPrivacy = new Subclient(
                 new DataPrivacyApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Events = new Subclient(
                 new EventsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Flows = new Subclient(
                 new FlowsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Forms = new Subclient(
                 new FormsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Images = new Subclient(
                 new ImagesApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Lists = new Subclient(
                 new ListsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Metrics = new Subclient(
                 new MetricsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Profiles = new Subclient(
                 new ProfilesApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Reporting = new Subclient(
                 new ReportingApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Reviews = new Subclient(
                 new ReviewsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Segments = new Subclient(
                 new SegmentsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Tags = new Subclient(
                 new TagsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Templates = new Subclient(
                 new TemplatesApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->TrackingSettings = new Subclient(
                 new TrackingSettingsApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
         $this->Webhooks = new Subclient(
                 new WebhooksApi(new GuzzleClient($this->guzzle_options),$this->config),
                 $wait_seconds = $this->wait_seconds,
                 $num_retries = $this->num_retries,
             );
-        
+
 
     }
 }

--- a/lib/Subclient.php
+++ b/lib/Subclient.php
@@ -3,23 +3,42 @@ namespace KlaviyoAPI;
 
 use KlaviyoAPI\ApiException;
 
+/**
+ * @template TWraps object
+ * @mixin TWraps
+ */
 class Subclient {
 
+    /** @var object */
     public $api_instance;
+    /** @var int */
     public $wait_seconds;
+    /** @var int */
     public $num_retries;
+    /** @var array */
     public $retry_codes;
 
     // vars for exponential backoff
+    /** @var float */
     public $base_interval = 0.5;
+    /** @var int */
     public $max_interval = 60;
+    /** @var float */
     public $multiplier = 1.5;
+    /** @var float */
     public $rand_factor = 0.5;
 
+    /** @var array<int, string> */
     public $_CURSOR_SEARCH_TOKENS;
 
+    /**
+     * @param object $api_instance
+     * @param ?int $wait_seconds
+     * @param int $num_retries
+     * @param array<int> $retry_codes
+     */
     public function __construct(
-        $api_instance, 
+        $api_instance,
         $wait_seconds = null,
         $num_retries = 3,
         $retry_codes = [429,503,504,524]
@@ -129,6 +148,6 @@ class Subclient {
         }
 
         $cursor = urldecode($cursor);
-        return $cursor;                
+        return $cursor;
     }
 }


### PR DESCRIPTION
Using the API is not very friendly as it does not hint the types and so you constantly have to look things up either in code or docs since the IDE is not able to reason about the code. Also the lack of types prevents static analyzers from validating that the code has been written correctly.

I have added some basic hints to the main class, but there appears to be more room for improvements.